### PR TITLE
Update AdvantageKit

### DIFF
--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,32 +1,32 @@
 {
     "fileName": "AdvantageKit.json",
     "name": "AdvantageKit",
-    "version": "1.2.0",
+    "version": "1.4.0",
     "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
     "mavenUrls": [],
-    "jsonUrl": "https://github.com/Mechanical-Advantage/AdvantageKit/releases/download/v1.2.0/AdvantageKit.json",
+    "jsonUrl": "https://github.com/Mechanical-Advantage/AdvantageKit/releases/download/v1.4.0/AdvantageKit.json",
     "javaDependencies": [        
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "wpilib-shim",
-            "version": "1.2.0"
+            "version": "1.4.0"
         },        
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "junction-core",
-            "version": "1.2.0"
+            "version": "1.4.0"
         },        
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-api",
-            "version": "1.2.0"
+            "version": "1.4.0"
         }
     ],
     "jniDependencies": [        
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-wpilibio",
-            "version": "1.2.0",
+            "version": "1.4.0",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [


### PR DESCRIPTION
In case you haven’t seen [this post](https://www.chiefdelphi.com/t/introducing-logging-with-advantagekit/398612/8?u=jonahb55), AdvantageKit v1.2.0 has a critical issue that can cause the main robot program to hang. This has been fixed in the latest version. If you’re planning to use AdvantageKit, I would highly suggest updating as there are no breaking changes as of v1.4.0 (which is currently the latest update).

Also feel free to close this pull request and update on whatever branch makes the most sense.

Jonah